### PR TITLE
Fix double callback call

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -35,15 +35,11 @@ export default Base => class extends InputClass(Base) {
     }
 
     _onInputMouseLeave(e) {
-        super._onInputMouseLeave(e);
-
         this.setState({
             pressed: false
         });
-
-        if (this.props.onMouseLeave) {
-            this.props.onMouseLeave(e);
-        }
+        
+        super._onInputMouseLeave(e);
     }
 
     render() {

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -38,7 +38,7 @@ export default Base => class extends InputClass(Base) {
         this.setState({
             pressed: false
         });
-        
+
         super._onInputMouseLeave(e);
     }
 


### PR DESCRIPTION
`onMouseLeave` already called in `super._onInputMouseLeave(e)`
setState before calling callback